### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "beapi/wp-cli-light-db-export",
   "description": "Database export",
+  "type": "wp-cli-package",
   "homepage": "https://github.com/beapi/wp-cli-light-db-export",
   "license": "MIT",
   "require": {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
