### PR TITLE
fallback to querying the dataname name is `dbname` property is null

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/beapi/wp-cli-light-db-export",
   "license": "MIT",
   "require": {
-    "php": ">=5.6"
+    "php": ">=7.0"
   },
   "authors": [
     {

--- a/src/wp-cli-light-db-export.php
+++ b/src/wp-cli-light-db-export.php
@@ -185,7 +185,10 @@ class WP_CLI_DB_Light_Export extends WP_CLI_DB_Light_Export_Base {
 	public function export( $positional_args, $assoc_args = [] ) {
 		global $wpdb;
 
-		$database_name = $wpdb->dbname;
+		$database_name = $wpdb->dbname ?? $wpdb->get_var('SELECT DATABASE();'); // fallback to querying the database if `dbname` is not defined
+		if ( empty( $database_name ) ) {
+			\WP_CLI::error( "Couldn't get database's name" );
+		}
 
 		/**
 		 * Filename to export (required)


### PR DESCRIPTION
Handle case where the `dbname` property is null. This can happen with custom `wpdb` dropin like hyperdb.